### PR TITLE
feat: change simple sequence divider --- for a more robust alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ python -m sequencer sequence.md -m "claude-3-5-sonnet-20240620" "meta-llama/Meta
 ```
 
 
----
+[!---seq-div---!]
 
 # Sequencer
 
@@ -55,7 +55,7 @@ Create a markdown file with your sequence. The first section becomes the system 
 You are a helpful assistant.
 ```
 
----
+[!---seq-div---!]
 # First Prompt
 ```
 What is artificial intelligence?

--- a/src/sequencer/blueprints/adwordscampaign.md
+++ b/src/sequencer/blueprints/adwordscampaign.md
@@ -68,7 +68,7 @@ KI:
 
 
 
----
+[!---seq-div---!]
 
 # routine 
 
@@ -81,7 +81,7 @@ run the # routine exactly
 - store them in ``<memory>`` 
 
 
----
+[!---seq-div---!]
 
 ## create a set of keywords 
 
@@ -93,7 +93,7 @@ run the # routine exactly
 	- >> cogit pattern @theory of mind ?what does user want, really 
 
 
----
+[!---seq-div---!]
 
 ## review the keywords 
 
@@ -104,7 +104,7 @@ run the # routine exactly
 - store it in ``<memory><keywords>``
 
 
----
+[!---seq-div---!]
 
 ## provide headlines for Google Ads 
 
@@ -113,7 +113,7 @@ run the # routine exactly
 - based on the keywords
 
 
----
+[!---seq-div---!]
 
 ## provide ad texts for Google Ads 
 
@@ -121,7 +121,7 @@ run the # routine exactly
 - based on the keywords
 
 
----
+[!---seq-div---!]
 
 ## review the headlines and ad texts 
 
@@ -133,14 +133,14 @@ run the # routine exactly
 - store it in ``<memory><headlines>`` and ``<memory><ad texts>``
 
 
----
+[!---seq-div---!]
 
 ## create an image description 
 
 - generate an image description based on each pair of ``<headline>`` and ``<ad text>``
 
 
----
+[!---seq-div---!]
 
 ## create an image prompt 
 
@@ -148,7 +148,7 @@ run the # routine exactly
 - store in ``<memory><image prompts>``
 
 
----
+[!---seq-div---!]
 
 # format 
 

--- a/src/sequencer/blueprints/contentcalendar.md
+++ b/src/sequencer/blueprints/contentcalendar.md
@@ -84,7 +84,7 @@ Ensure all content ideas align with the themes and topics provided by @Marketing
 - confirm you understood the task 
 
 
----
+[!---seq-div---!]
 # context
 
 ## project description
@@ -134,7 +134,7 @@ Die Genossenschaftsbanken möchten ihre Rolle als **nahbarer und verlässlicher 
 - confirm you understood the task 
 
 
----
+[!---seq-div---!]
 
 # routine
 
@@ -145,7 +145,7 @@ Die Genossenschaftsbanken möchten ihre Rolle als **nahbarer und verlässlicher 
 - Extract key objectives, target audience, and promotional goals.
 - Store the insights in `<memory>`.
 
----
+[!---seq-div---!]
 
 ## set monthly overarching themes
 
@@ -154,7 +154,7 @@ Die Genossenschaftsbanken möchten ihre Rolle als **nahbarer und verlässlicher 
 - Align themes with business objectives, seasonal trends, and campaign goals.
 - Store in `<memory><monthly themes>`.
 
----
+[!---seq-div---!]
 
 ## plan weekly content topics
 
@@ -163,7 +163,7 @@ Die Genossenschaftsbanken möchten ihre Rolle als **nahbarer und verlässlicher 
 - Ensure topics are relevant and varied.
 - Store in `<memory><weekly topics>`.
 
----
+[!---seq-div---!]
 
 ## create a content type plan
 
@@ -172,7 +172,7 @@ Die Genossenschaftsbanken möchten ihre Rolle als **nahbarer und verlässlicher 
 - Include a balanced mix to cater to different platforms and audience preferences.
 - Store in `<memory><content type plan>`.
 
----
+[!---seq-div---!]
 
 ## provide detailed content ideas
 
@@ -184,7 +184,7 @@ Die Genossenschaftsbanken möchten ihre Rolle als **nahbarer und verlässlicher 
 	- **CTA**: A compelling call-to-action tailored to the content type and audience.
 - Store in `<memory><content ideas>`.
 
----
+[!---seq-div---!]
 
 ## create a posting schedule
 
@@ -193,7 +193,7 @@ Die Genossenschaftsbanken möchten ihre Rolle als **nahbarer und verlässlicher 
 - Ensure consistency and avoid overlapping schedules.
 - Store in `<memory><posting schedule>`.
 
----
+[!---seq-div---!]
 
 ## review the content calendar
 
@@ -202,7 +202,7 @@ Die Genossenschaftsbanken möchten ihre Rolle als **nahbarer und verlässlicher 
 - Ensure all elements align with business objectives and audience needs.
 - Finalize and store in `<memory><content calendar>`.
 
----
+[!---seq-div---!]
 --end--
 # format
 
@@ -232,5 +232,5 @@ Strictly follow this template:
 ]
 </output>
 
----
+[!---seq-div---!]
 

--- a/src/sequencer/blueprints/contractcheck.md
+++ b/src/sequencer/blueprints/contractcheck.md
@@ -11,7 +11,7 @@ Primary Objectives:
 3. Propose detailed improvements
 4. Generate structured documentation
 
----
+[!---seq-div---!]
 
 # data 
 ## contents
@@ -126,7 +126,7 @@ _(Arbeitnehmer)_
 - Summarize the # data 
 - Propose a plan of action 
 
---- 
+[!---seq-div---!] 
 
 # COMPLETENESS ANALYSIS
 
@@ -164,7 +164,7 @@ Output Structure:
 - Missing Elements: [List]
 - Improvement Recommendations: [Detailed Suggestions]
 
----
+[!---seq-div---!]
 
 # VERIFICATION
 
@@ -210,7 +210,7 @@ Verification Output:
 - Consistency Review: [Findings]
 - Required Adjustments: [List]
 
----
+[!---seq-div---!]
 
 # LEGAL COMPLIANCE REVIEW
 
@@ -258,7 +258,7 @@ Tasks:
 - Respond directly in the chat, do not use Canvas or Artifacts
 
 
----
+[!---seq-div---!]
 
 # VERIFICATION
 
@@ -304,7 +304,7 @@ Verification Output:
 - Consistency Review: [Findings]
 - Required Adjustments: [List]
 
----
+[!---seq-div---!]
 
 # POLICY ALIGNMENT CHECK
 
@@ -351,7 +351,7 @@ Tasks:
 - Respond directly in the chat, do not use Canvas or Artifacts
 
 
----
+[!---seq-div---!]
 
 # VERIFICATION
 
@@ -397,7 +397,7 @@ Verification Output:
 - Consistency Review: [Findings]
 - Required Adjustments: [List]
 
----
+[!---seq-div---!]
 
 # CLAUSE DISADVANTAGE ASSESSMENT
 
@@ -444,7 +444,7 @@ Tasks:
 - Respond directly in the chat, do not use Canvas or Artifacts
 
 
----
+[!---seq-div---!]
 
 # VERIFICATION
 
@@ -490,7 +490,7 @@ Verification Output:
 - Consistency Review: [Findings]
 - Required Adjustments: [List]
 
----
+[!---seq-div---!]
 
 # CLARITY AND AMBIGUITY CHECK
 
@@ -541,7 +541,7 @@ Tasks:
 - Respond directly in the chat, do not use Canvas or Artifacts
 
 
----
+[!---seq-div---!]
 
 # VERIFICATION
 
@@ -587,7 +587,7 @@ Verification Output:
 - Consistency Review: [Findings]
 - Required Adjustments: [List]
 
----
+[!---seq-div---!]
 
 # COMPREHENSIVE OUTPUT GENERATION
 
@@ -646,7 +646,7 @@ Tasks:
 - Respond directly in the chat, do not use Canvas or Artifacts
 
 
----
+[!---seq-div---!]
 
 # VERIFICATION
 
@@ -692,7 +692,7 @@ Verification Output:
 - Consistency Review: [Findings]
 - Required Adjustments: [List]
 
----
+[!---seq-div---!]
 
 # FINAL QUALITY ASSURANCE
 
@@ -883,7 +883,7 @@ This expanded structure ensures:
 - Respond directly in the chat, do not use Canvas or Artifacts
 
 
----
+[!---seq-div---!]
 
 # MASTER VERIFICATION
 

--- a/src/sequencer/blueprints/cvcheck.md
+++ b/src/sequencer/blueprints/cvcheck.md
@@ -26,7 +26,7 @@ Review the role requirements and outline your question generation plan.
 
 Then wait for the candidate information.
 
----
+[!---seq-div---!]
 
 # requirements
 
@@ -119,7 +119,7 @@ analyze the file and also generate questions that address gaps in the file compa
 
 make sure that the file content is relevant for the role description. if not the case, simply reply with "candidate irrelevant" 
 
----
+[!---seq-div---!]
 
 # verify the consistency
 
@@ -138,7 +138,7 @@ use a schema as bulletpoints:
 - mini quote file content 
 - mini quote role description
 
----
+[!---seq-div---!]
 
 
 # verify once again 
@@ -150,7 +150,7 @@ output only the list of refined questions
 avoid any comments at the beginning or the end of your message
 
 
----
+[!---seq-div---!]
 
 # assess candidate answers 
 

--- a/src/sequencer/blueprints/generator.md
+++ b/src/sequencer/blueprints/generator.md
@@ -108,7 +108,7 @@ define @evaluator (
 </routine> 
 
 
----
+[!---seq-div---!]
 
 # analyze the requirements 
 
@@ -204,7 +204,7 @@ Include key themes, content goals, target platforms, tone of voice, etc."""
 
 </examples>
 
----
+[!---seq-div---!]
 
 # review the new methods and functions
 
@@ -213,7 +213,7 @@ Include key themes, content goals, target platforms, tone of voice, etc."""
 - review the new methods and functions in great detail
 - propose changes and adaptations if necessary 
 
----
+[!---seq-div---!]
 
 # review proposed changes 
 
@@ -222,7 +222,7 @@ Include key themes, content goals, target platforms, tone of voice, etc."""
 - review proposals by @discriminator
 - critically consider them and implement what is necessary 
 
----
+[!---seq-div---!]
 
 # evaluate the results and make a decision 
 

--- a/src/sequencer/blueprints/scoper.md
+++ b/src/sequencer/blueprints/scoper.md
@@ -24,7 +24,7 @@ First message:
 Review this text and outline a quick plan of action. Then wait for the requirements document.
 
 
----
+[!---seq-div---!]
 
 # requirements 
 
@@ -38,7 +38,7 @@ Review this text and outline a quick plan of action. Then wait for the requireme
 2. wait until scoping examples are sent 
 
 
----
+[!---seq-div---!]
 
 
 # examples of scoping documents
@@ -58,7 +58,7 @@ Review this text and outline a quick plan of action. Then wait for the requireme
 7. generate a new scoping document with all sections
 
 
----
+[!---seq-div---!]
 
 
 # validate the consistency 
@@ -71,7 +71,7 @@ between requirements and new scoping document
 - outline mistakes and improvement suggestions 
 
 
----
+[!---seq-div---!]
 
 
 # review and implement the changes 

--- a/src/sequencer/blueprints/sequence.md
+++ b/src/sequencer/blueprints/sequence.md
@@ -3,7 +3,7 @@
 You are a helpful assistant.
 ```
 
----
+[!---seq-div---!]
 # First Prompt
 ```
 What is artificial intelligence?

--- a/src/sequencer/blueprints/solver.md
+++ b/src/sequencer/blueprints/solver.md
@@ -97,7 +97,7 @@ def load_directory_filtered(directory: str) -> List[Document]:
 
 </error>
 
----
+[!---seq-div---!]
 
 # review the code
 
@@ -106,7 +106,7 @@ def load_directory_filtered(directory: str) -> List[Document]:
 - review the code in great detail
 - propose changes and adaptations if necessary 
 
----
+[!---seq-div---!]
 
 # review proposed changes 
 

--- a/src/sequencer/blueprints/tester.md
+++ b/src/sequencer/blueprints/tester.md
@@ -56,7 +56,7 @@ define @optimizer (
 
 </routine> 
 
----
+[!---seq-div---!]
 
 # create tests for the following code
 
@@ -102,7 +102,8 @@ class SequenceReader:
         # Remove any content after --end-- marker if present
         content = re.split(r'\n--end--\s*\n', content.strip())[0]
         
-        sections = re.split(r'\n---+\n', content.strip())
+        # Split on a line that contains exactly the divider token, allowing surrounding whitespace
+        sections = re.split(r'^\s*\[!---seq-div---!\]\s*$', content.strip(), flags=re.MULTILINE)
         result = []
         
         for i, section in enumerate(sections, 1):
@@ -151,7 +152,7 @@ def read_sequence(file_path: str | Path) -> List[PromptSection]:
     content = reader.read_content()
     return reader.parse_sections(content)
 
----
+[!---seq-div---!]
 
 # review the testing and performance results
 
@@ -160,7 +161,7 @@ def read_sequence(file_path: str | Path) -> List[PromptSection]:
 - review the testing outcomes and performance evaluation in great detail
 - propose changes and adaptations if necessary 
 
----
+[!---seq-div---!]
 
 # review proposed changes 
 

--- a/src/sequencer/main.py
+++ b/src/sequencer/main.py
@@ -88,7 +88,7 @@ def get_sequence_path(filename: str) -> Path:
 You are a helpful assistant.
 ```
 
----
+[!---seq-div---!]
 # First Prompt
 ```
 What is artificial intelligence?

--- a/src/sequencer/reader.py
+++ b/src/sequencer/reader.py
@@ -40,7 +40,8 @@ class SequenceReader:
         # Remove any content after --end-- marker if present
         content = re.split(r'\n--end--\s*\n', content.strip())[0]
         
-        sections = re.split(r'\n---+\n', content.strip())
+        # Split on a line that contains exactly the divider token, allowing surrounding whitespace
+        sections = re.split(r'^\s*\[!---seq-div---!\]\s*$', content.strip(), flags=re.MULTILINE)
         result = []
         
         for i, section in enumerate(sections, 1):

--- a/src/sequencer/writer.py
+++ b/src/sequencer/writer.py
@@ -34,12 +34,12 @@ class ResultWriter:
                 for result in results:
                     f.write(f"# {result.title}\n\n")
                     f.write(f">> user:\n\n```\n{result.content}\n```\n\n")
-                    f.write("---\n\n")
+                    f.write("[!---seq-div---!]\n\n")
                     if result.error:
                         f.write(f"error: {result.error}\n\n")
                     else:
                         f.write(f">> ai:\n\n{result.response}\n\n")
-                    f.write("---\n\n")
+                    f.write("[!---seq-div---!]\n\n")
 
 def write_results(results: List[RunResult], output_dir: str | Path = "results") -> None:
     """Write results to markdown files"""


### PR DESCRIPTION
To improve the robustness of the sequence divider token, we're implementing a new unique token that differentiates from the previous three dashes '---'.

While this solution takes a few more seconds to write for the user, it results no collision with standard markdown syntax, as well as difficulty for the LLM to come up with the same new [!---seq-div---!] pattern which would potentially break the blueprint sequence's divisions.

# Sub-Tasks
- [x] update regex in reader.py and writer.py
- [x] update existing blueprints MD dividers for compatibility
- [x] Tested locally with ChatGPT-4o-mini. (ran with tester.md, cvcheck.md)
- [x] Explored edgecases, and it ran correctly.

I'm able to answer any questions or update the unique divider token to something else, if necessary!